### PR TITLE
Add alert when resources cannot be found

### DIFF
--- a/src/main/java/common/BaseLogger.java
+++ b/src/main/java/common/BaseLogger.java
@@ -108,6 +108,9 @@ public class BaseLogger {
      * @param level   The level to log at.
      */
     private void print(String message, String level) {
+        if (message == null) {
+            message = "<null message>";
+        }
         String msg = this.format(this._format, level);
         if (msg.contains("%(message)")) {
             msg = msg.replace("%(message)", message);

--- a/src/main/java/common/exceptions/LoadMapFailedException.java
+++ b/src/main/java/common/exceptions/LoadMapFailedException.java
@@ -1,0 +1,14 @@
+package common.exceptions;
+
+/**
+ * An exception to be thrown when CodeCarnage fails to load the game map
+ *
+ * @author jacob.ekstrum
+ */
+public class LoadMapFailedException extends ResourceNotFoundException {
+
+    public LoadMapFailedException() {super();}
+
+    public LoadMapFailedException(String message) {super(message);}
+
+}

--- a/src/main/java/common/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/common/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,17 @@
+package common.exceptions;
+
+/**
+ * Exception class to be thrown or subclasses when a resource cannot be found in CodeCarnage.
+ *
+ * @author jacob.ekstrum
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException() {
+        super();
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Closes #150 . 
### Alerts user when resources can't be found
Alerts the user as a last resort when resources cannot be found so that they at least know why the program is going down.
### Logger patch
Patches a `NullPointerException` in the Logger class when a null string is passed in as the message. The message will be recreated to say "<null message>".
### Safer Exceptions
Adds an exceptions folder and populates with two new Exceptions (`ResourceNotFoundException` and `LoadMapFailedException`) - one of which  is used to identify when the map fails to load and should not be thrown elsewhere. This could be useful if we ever implement map switching.