### PR TITLE
Update downloads information to inform about requirements

### DIFF
--- a/website/me/downloads/index.html
+++ b/website/me/downloads/index.html
@@ -66,7 +66,7 @@
   <div class="jumbotron vertical-center">
       <div class="container">
           <h1 class="display-3">Get in the game.</h1>
-          <p class="lead">Start your scripting adventures today.</p>
+          <p class="lead">Script your way to glory.</p>
           <p class="my-4">
               <a href="https://github.com/j3kstrum/CodeCarnage/raw/master/CodeCarnage-all.jar" class="btn btn-secondary btn-lg">
                   <i class="fa fa-download"></i>
@@ -77,6 +77,15 @@
               <a href="https://github.com/j3kstrum/CodeCarnage" class="btn btn-secondary btn-lg">
                   <i class="fa fa-github fa-fw"></i>
                   <span class="network-name">Clone From Source</span>
+              </a>
+          </p>
+          <p class="lead">CodeCarnage requires Java 1.8 or greater in order to play. If CodeCarnage does not start
+              when you double-click the file downloaded above, try downloading Java below.
+          </p>
+          <p class="my-4">
+              <a href="https://java.com/en/download/" class="btn btn-secondary btn-sm">
+                  <i class="fa fa-coffee fa-fw"></i>
+                  <span class="network-name">Get Java</span>
               </a>
           </p>
       </div>


### PR DESCRIPTION
Closes #186 . Updates the downloads page to keep a minimalist theme but still guide the user to download java in case of failure.