### PR TITLE
Update contact page to reflect official release

### DIFF
--- a/website/me/contact/index.html
+++ b/website/me/contact/index.html
@@ -83,13 +83,12 @@
               General Feedback
             </h2>
             <p class="lead">
-              During CodeCarnage's beta release, the CodeCarnage developers are hoping for large amounts of feedback.
-              If you would like to help the CodeCarnage developers increase the quality of the game for the official
-              release, please visit
+              While
               <a href="https://docs.google.com/forms/d/e/1FAIpQLSeq1g16EzCJb4672akXduBethIvmSq0NByL3OAKdD76kwKIMQ/viewform?usp=sf_link">
                 the CodeCarnage response form
               </a>
-              .
+               was originally intended to be used to refine the beta release for the official release,
+              we are still accepting general feedback through this form.
             </p>
           </div>
           <div class="col-lg-5 mr-auto">
@@ -111,7 +110,6 @@
               Bug Reports
             </h2>
             <p class="lead">
-              Since CodeCarnage is still in its beta release, it is expected that there will be bugs found.
               If you encounter a bug in the software, please let us know
               <a href="https://github.com/j3kstrum/CodeCarnage/issues/new?labels=bug&title=Bug%20Found:%20%3CYour%20Bug%20Description%20Here%3E&body=A%20bug%20was%20found%20while%20testing%20CodeCarnage.%0D%0A%0D%0ADetails:%0D%0A%0D%0A*%20Operating%20System:%20%0D%0A*%20Java%20Version,%20if%20known:%20%0D%0A%0D%0A**What%20Happened:**%20">
                 by creating a bug issue on our GitHub page


### PR DESCRIPTION
Removes the beta release jargon and replaces it with official release text in the website. Particularly, the contact page was the only part that actually alluded to being in the beta release.

Closes #223 .